### PR TITLE
Provide context object for dynamic filters

### DIFF
--- a/docs/disambiguation.md
+++ b/docs/disambiguation.md
@@ -197,7 +197,8 @@ parser = Parser(grammar, dynamic_filter=custom_disambiguation_filter)
 Where resolution function is of the following form:
 
 ```
-def custom_disambiguation_filter(action, token, production, subresults, state):
+def custom_disambiguation_filter(action, token, production, subresults, state,
+                                 context):
     """Make first operation that appears in the input as lower priority.
     This demonstrates how priority rule can change dynamically depending
     on the input.

--- a/parglare/glr.py
+++ b/parglare/glr.py
@@ -82,18 +82,18 @@ class GLRParser(Parser):
 
         self.errors = []
         self.current_error = None
+        self.context = context = context if context else Context()
 
         # Initialize dynamic disambiguation
         if self.dynamic_filter:
             if self.debug:
                 prints("\tInitializing dynamic disambiguation.")
-            self.dynamic_filter(None, None, None, None, None, context)
+            self.dynamic_filter(None, None, None, None, None, self.context)
 
         self.last_position = 0
         self.expected = set()
         self.empty_reductions_results = {}
 
-        self.context = context = context if context else Context()
         context.parser = self
         context.input_str = input_str
         context.file_name = file_name

--- a/parglare/glr.py
+++ b/parglare/glr.py
@@ -87,7 +87,7 @@ class GLRParser(Parser):
         if self.dynamic_filter:
             if self.debug:
                 prints("\tInitializing dynamic disambiguation.")
-            self.dynamic_filter(None, None, None, None, None)
+            self.dynamic_filter(None, None, None, None, None, context)
 
         self.last_position = 0
         self.expected = set()
@@ -322,7 +322,7 @@ class GLRParser(Parser):
             if action and action.action is SHIFT:
                 if self.dynamic_filter and \
                     not self._call_dynamic_filter(
-                            SHIFT, token, None, None, state):
+                            SHIFT, token, None, None, state, context):
                         pass
                 else:
                     self.shift(head, token, action.state, context)
@@ -348,7 +348,8 @@ class GLRParser(Parser):
         if not prod_len:
             if self.dynamic_filter and \
                 not self._call_dynamic_filter(
-                        REDUCE, token_ahead, production, [], head.state):
+                        REDUCE, token_ahead, production, [], head.state,
+                        context):
                     pass
             else:
                 context.end_position = context.start_position
@@ -433,7 +434,7 @@ class GLRParser(Parser):
                 if self.dynamic_filter and \
                     not self._call_dynamic_filter(REDUCE, token_ahead,
                                                   production, subresults,
-                                                  head.state):
+                                                  head.state, context):
                         pass
                 else:
                     new_state = root.state.gotos[production.symbol]

--- a/parglare/parser.py
+++ b/parglare/parser.py
@@ -145,7 +145,7 @@ class Parser(object):
         if self.dynamic_filter:
             if self.debug:
                 prints("\tInitializing dynamic disambiguation.")
-            self.dynamic_filter(None, None, None, None, None)
+            self.dynamic_filter(None, None, None, None, None, context)
 
         state_stack = [StackNode(self.table.states[0], position, 0, None,
                                  None)]
@@ -271,7 +271,7 @@ class Parser(object):
                 for a in acts:
                     if a.action is SHIFT:
                         if self._call_dynamic_filter(
-                                SHIFT, ntok, None, None, cur_state):
+                                SHIFT, ntok, None, None, cur_state, context):
                             dacts.append(a)
                     elif a.action is REDUCE:
                         r_len = len(a.prod.rhs)
@@ -281,7 +281,8 @@ class Parser(object):
                         else:
                             subresults = []
                         if self._call_dynamic_filter(
-                                REDUCE, ntok, a.prod, subresults, cur_state):
+                                REDUCE, ntok, a.prod, subresults, cur_state,
+                                context):
                             dacts.append(a)
                     else:
                         dacts.append(a)
@@ -705,7 +706,7 @@ class Parser(object):
             return error, position + 1, None
 
     def _call_dynamic_filter(self, action, token, production, subresults,
-                             state):
+                             state, context):
         if (action is SHIFT and not token.symbol.dynamic)\
            or (action is REDUCE and not production.dynamic):
             return True
@@ -721,7 +722,7 @@ class Parser(object):
                         if action is REDUCE else ""), level=2)
 
         accepted = self.dynamic_filter(action, token, production, subresults,
-                                       state)
+                                       state, context)
         if self.debug:
             if accepted:
                 a_print("Action accepted.", level=2)

--- a/tests/func/test_dynamic_disambiguation_filters.py
+++ b/tests/func/test_dynamic_disambiguation_filters.py
@@ -29,7 +29,8 @@ g = Grammar.from_string(grammar)
 operations = []
 
 
-def custom_disambiguation_filter(action, token, production, subresults, state):
+def custom_disambiguation_filter(action, token, production, subresults, state,
+                                 context):
     """Make first operation that appears in the input as lower priority.
     This demonstrates how priority rule can change dynamically depending
     on the input.


### PR DESCRIPTION
Context object can be useful while debugging, since it is possible
to find out an exact position in the `input_str` for which the filter
is called.