### PR TITLE
Fix to only discard recognizer return values if they are None.

### DIFF
--- a/parglare/parser.py
+++ b/parglare/parser.py
@@ -536,7 +536,7 @@ class Parser(object):
                 break
             last_prior = symbol.prior
             tok = symbol.recognizer(input_str, position)
-            if tok:
+            if tok is not None:
                 tokens.append(Token(symbol, tok))
                 if finish_flags[idx]:
                     break


### PR DESCRIPTION
The previous behavior was to discard return values if they evaluated as False.