### PR TITLE
Allow for manual parse table loading

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -133,6 +133,22 @@ calculation you can set `force_load_table` to `True`. If this flag is set no
 modification check will be performed and table calculation will happen only if
 `.pgt` file doesn't exist.
 
+## table
+
+You can pass precomputed parsing table here. This is useful for implementing
+custom parse table caching. `None` value for this parameter (the default)
+instructs parser to build (or fetch from cache) it's own tables internally.
+
+Example flow for custom caching is shown in
+[an example](/examples/custom_table_caching).
+
+!!! warning
+
+    Be careful to provide parse tables compatibile with parser type. Passing
+    tables containing conflicts to `Parser` class will propably result in an
+    error, but passing tables with automatically resolved conflicts
+    (`prefer_shifts=True`) to `GLRParser` will result in parser which may skip
+    proper parses.
 
 # `parse` and `parse_file` calls
 

--- a/examples/custom_table_caching/.gitignore
+++ b/examples/custom_table_caching/.gitignore
@@ -1,0 +1,1 @@
+_table.py

--- a/examples/custom_table_caching/README.md
+++ b/examples/custom_table_caching/README.md
@@ -1,0 +1,10 @@
+Custom parse table caching example
+==================================
+
+Parse table is stored as a python module (`_table.py`). To generate it, in this directory run:
+
+    python compile.py
+
+Then precomputed parse table is used in parser script
+
+    python parser.py

--- a/examples/custom_table_caching/compile.py
+++ b/examples/custom_table_caching/compile.py
@@ -1,0 +1,22 @@
+import json
+from parglare.tables import create_table, LALR
+from parglare.tables.persist import table_to_serializable
+
+from grammar import grammar, start_symbol
+
+
+table = create_table(
+    grammar,
+    start_production=grammar.get_production_id(start_symbol),
+    itemset_type=LALR,
+    prefer_shifts=False,
+    prefer_shifts_over_empty=False,
+)
+serializable_table = table_to_serializable(table)
+
+# passing it thorugh json to convert OrderedDicts into ordinary dicts
+serializable_table = json.loads(json.dumps(serializable_table))
+
+with open('_table.py', 'w') as f:
+    f.write('table = ')
+    f.write(repr(serializable_table))

--- a/examples/custom_table_caching/grammar.py
+++ b/examples/custom_table_caching/grammar.py
@@ -1,0 +1,9 @@
+from parglare import Grammar
+
+
+grammar = Grammar.from_string("""
+    start: ab EOF;
+    ab: "a" ab "b" | EMPTY;
+""")
+
+start_symbol = 'start'

--- a/examples/custom_table_caching/parser.py
+++ b/examples/custom_table_caching/parser.py
@@ -1,0 +1,11 @@
+from parglare import GLRParser
+from parglare.tables.persist import table_from_serializable
+
+from _table import table
+from grammar import grammar
+
+
+table = table_from_serializable(table, grammar)
+parser = GLRParser(grammar, table=table)
+
+print(parser.parse('aaabbb'))

--- a/parglare/glr.py
+++ b/parglare/glr.py
@@ -46,7 +46,7 @@ class GLRParser(Parser):
         if table is None:
             # The default for GLR is not to use any strategy preferring shifts
             # over reduce thus investigating all possibilitites.
-            # This settings are only applicable if prase table is not computed
+            # These settings are only applicable if parse table is not computed
             # yet. If it is, then leave None values to avoid
             # "parameter overriden" warnings.
             prefer_shifts = False \

--- a/parglare/glr.py
+++ b/parglare/glr.py
@@ -40,14 +40,20 @@ class GLRParser(Parser):
                  tables=LALR, return_position=False,
                  prefer_shifts=None, prefer_shifts_over_empty=None,
                  error_recovery=False, dynamic_filter=None,
-                 custom_token_recognition=None, force_load_table=False):
+                 custom_token_recognition=None, force_load_table=False,
+                 table=None):
 
-        # The default for GLR is not to use any strategy preferring shifts
-        # over reduce thus investigating all possibilitites.
-        prefer_shifts = False \
-            if prefer_shifts is None else prefer_shifts
-        prefer_shifts_over_empty = False \
-            if prefer_shifts_over_empty is None else prefer_shifts_over_empty
+        if table is None:
+            # The default for GLR is not to use any strategy preferring shifts
+            # over reduce thus investigating all possibilitites.
+            # This settings are only applicable if prase table is not computed
+            # yet. If it is, then leave None values to avoid
+            # "parameter overriden" warnings.
+            prefer_shifts = False \
+                if prefer_shifts is None else prefer_shifts
+            prefer_shifts_over_empty = False \
+                if prefer_shifts_over_empty is None \
+                else prefer_shifts_over_empty
 
         super(GLRParser, self).__init__(
             grammar=grammar, start_production=start_production,
@@ -61,7 +67,7 @@ class GLRParser(Parser):
             prefer_shifts_over_empty=prefer_shifts_over_empty,
             error_recovery=error_recovery, dynamic_filter=dynamic_filter,
             custom_token_recognition=custom_token_recognition,
-            force_load_table=force_load_table)
+            force_load_table=force_load_table, table=table)
 
     def _check_parser(self):
         """

--- a/parglare/tables/persist.py
+++ b/parglare/tables/persist.py
@@ -2,26 +2,30 @@ import json
 from collections import OrderedDict
 
 
-def save_table(file_name, table):
-
+def table_to_serializable(table):
+    """Convert table object to serializable representation composed of
+    lists and dicts."""
     # states
     states = []
     for state in table.states:
         states.append(_dump_state(state))
 
+    return states
+
+
+def save_table(file_name, table):
     with open(file_name, 'w') as f:
-        json.dump(states, f)
+        json.dump(table_to_serializable(table), f)
 
 
-def load_table(file_name, grammar):
+def table_from_serializable(serialized_states, grammar):
+    """Convert serializable representation of a parsing table into
+    LRTable object."""
     from parglare.tables import LRState, LRTable, Action
-
-    with open(file_name) as f:
-        json_states = json.load(f)
 
     states = []
     states_dict = {}
-    for json_state in json_states:
+    for json_state in serialized_states:
         state = LRState(grammar, json_state['state_id'],
                         grammar.get_symbol(json_state['symbol']))
         states_dict[state.state_id] = state
@@ -62,6 +66,11 @@ def load_table(file_name, grammar):
     table = LRTable(states, calc_finish_flags=False)
 
     return table
+
+
+def load_table(file_name, grammar):
+    with open(file_name) as f:
+        return table_from_serializable(json.load(f), grammar)
 
 
 def _dump_state(state):

--- a/tests/func/test_parser_construction.py
+++ b/tests/func/test_parser_construction.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import sys
+HAS_MOCK = sys.version_info[0] >= 3
+if HAS_MOCK:
+    from unittest.mock import patch
 import pytest  # noqa
 from parglare import Grammar, Parser, GLRParser, EMPTY, STOP, EOF
 from parglare.tables import first, follow, create_table, SHIFT, REDUCE
@@ -203,3 +207,17 @@ def test_prefer_shifts_over_empty_reductions():
     Test strategy that will choose SHIFT when in conflict with EMPTY reduction.
     """
     # TODO
+
+
+def test_precomputed_table():
+    """If parser is initialized with a `table` parameter then this table
+    should be used, and no call to create_table should be made."""
+    grammar = get_grammar()
+    table = create_table(grammar)
+    if HAS_MOCK:
+        with patch('parglare.tables.create_table') as mocked_create_table:
+            parser = GLRParser(grammar, table=table)
+            assert not mocked_create_table.called
+    else:
+        parser = GLRParser(grammar, table=table)
+    parser.parse('id+id')


### PR DESCRIPTION
This patch enables user to be able to create parse table and then load it in custom way, and from custom media, not just from JSON file of predefined name.

By default tables are precomputed and stored into `.pgt` file without any changes to the already existing flow.

One more change worth mentioning is that `start_production` is not stored as `Parser` field. It is used, but only as a scoped variable. For me it is a change in good direction as I mentioned in #80.