### PR TITLE
Failing tests on cyclic grammars with GLR parser

### DIFF
--- a/tests/func/grammar/test_special_grammars.py
+++ b/tests/func/grammar/test_special_grammars.py
@@ -101,11 +101,13 @@ def test_nondeterministic_LR_raise_error():
     assert len(results) == 1
 
 
+@pytest.mark.skip
 def test_cyclic_grammar_1():
     """
     From the paper: "GLR Parsing for e-Grammers" by Rahman Nozohoor-Farshi
     """
     grammar = """
+    S0: S EOF;
     S: A;
     A: S;
     A: 'x';
@@ -121,12 +123,14 @@ def test_cyclic_grammar_1():
     assert len(results) == 1
 
 
-def todo_test_cyclic_grammar_2():
+@pytest.mark.skip
+def test_cyclic_grammar_2():
     """
     From the paper: "GLR Parsing for e-Grammers" by Rahman Nozohoor-Farshi
 
     """
     grammar = """
+    S0: S EOF;
     S: S S;
     S: 'x';
     S: EMPTY;
@@ -136,7 +140,7 @@ def todo_test_cyclic_grammar_2():
     with pytest.raises(SRConflicts):
         Parser(g, prefer_shifts=False)
 
-    p = GLRParser(g, debug=True)
+    p = GLRParser(g)
     results = p.parse('xx')
 
     # This grammar has infinite ambiguity but by minimizing empty reductions


### PR DESCRIPTION
`test_cyclic_grammar_1` passes if grammar is left unterminated (without EOF). With EOF it seems to be going into infinite loop when parsing.

Same thing may be happening with `test_cyclic_grammar_2`, but i'm not 100% sure. Maybe it;s something different. I renamed that test to be processed by pytest and have marked it as skipped. (Skipped tests are better than prefixed with `todo_` [in my opinion], because they are manifesting themselves when all tests are run - `s` is printed and at the end you get skipped tests counter.)

I think it's ok to merge this PR right away (without fixing the issue).