### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -178,7 +178,7 @@ method of the parser object to execute actions. For example:
 
 parglare provides some common actions in the module `parglare.actions`. You can
 [reference these actions directly from the
-grammar](./grammar_language.md#referencing-rule-actions-from-a-grammar).
+grammar](./grammar_language.md#referencing-semantic-actions-from-a-grammar).
 Built-in actions are used implicitly by parglare as default actions in
 particular case (e.g. for [syntactic
 sugar](./grammar_language.md#syntactic-sugar-bnf-extensions)) but you might want

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -54,7 +54,7 @@ parser = Parser(grammar, debug=True)
 
 
 To debug [layout
-grammar](./grammar_language.md#handling-whitespaces-and-comments) do:
+grammar](./grammar_language.md#handling-whitespaces-and-comments-in-your-language) do:
 
 ```python
 parser = Parser(grammar, debug_layout=True)

--- a/docs/disambiguation.md
+++ b/docs/disambiguation.md
@@ -38,7 +38,7 @@ our language with a single interpretation for each of them and nothing more.
 
 Static disambiguation filters are given in the grammar at the end of the
 production using `{}` syntax. There is also
-a [dynamic disambiguation filter](./dynamic-disambiguation-filter) that is most
+a [dynamic disambiguation filter](#dynamic-disambiguation-filter) that is most
 powerful and is specified as a Python function.
 
 
@@ -265,7 +265,7 @@ Parameters are:
 - **subresults (list)** - a sub-results for the reduction. Valid only for
   REDUCE. The length of this list is equal to `len(production.rhs)`.
 
-For details see [test_dynamic_disambiguation_filters.py](https://github.com/igordejanovic/parglare/blob/master/tests/func/test_dynamic_disambiguation_filters.py).
+For details see [test_dynamic_disambiguation_filters.py](https://github.com/igordejanovic/parglare/blob/master/tests/func/parsing/test_dynamic_disambiguation_filters.py).
 
 
 ## Lexical ambiguities
@@ -333,7 +333,7 @@ token at the position.
 parglare solves this problem by enabling you to implement a custom token
 recognition by registering a callable during parser instantiation that will,
 during parsing, get all the symbols expected at the current location and return
-a list of tokens (instances of [`Token` class](./parser.md#token)) or `None`/
+a list of tokens (instances of [`Token` class](./parser.md#token-class)) or `None`/
 empty list if no symbol is found at the location.
 
 This callable is registered during parser instantiation as the parameter
@@ -354,7 +354,7 @@ The callable accepts:
   extend it with new tokens. See the example below how to return list with a
   token only if the default recognition doesn't succeed.
 
-**Returns:** a list of [`Token` class instances](./parser.md#token) or
+**Returns:** a list of [`Token` class instances](./parser.md#token-class) or
 `None`/empty list if no token is found.
 
 To instantiate `Token` pass in the symbol and the value of the token. Value of

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -93,7 +93,7 @@ This is a base class for `Terminal` and `NonTerminal`.
   about location in the file (position and span).
 
 - **action_name** - the action name assigned for the symbol. This is given in
-  the grammar using the [`@` syntax](./grammar_language.md#). If action name is
+  the grammar using the [`@` syntax](./grammar_language.md/#referencing-semantic-actions-from-a-grammar). If action name is
   not provided in the grammar symbol name is used.
 
 - **action_fqn** (property) - the fully qualiifed action name for the symbol.
@@ -152,7 +152,7 @@ This is a base class for `Terminal` and `NonTerminal`.
   priority is 10.
 
 - **dynamic (bool)** - `True` if this production disambiguation should
-  be [resolved dynamically]().
+  be [resolved dynamically](./disambiguation.md#dynamic-disambiguation-filter).
 
 - **prod_id (int)** - ordinal number of the production in the grammar,
 

--- a/docs/grammar_language.md
+++ b/docs/grammar_language.md
@@ -156,7 +156,7 @@ recognize a sublist of integers in ascending order.
 
 For more details on the usage
 see
-[this test](https://github.com/igordejanovic/parglare/blob/master/tests/func/test_recognizers.py).
+[this test](https://github.com/igordejanovic/parglare/blob/master/tests/func/recognizers/test_recognizers.py).
 
 More on this topic can be found in [a separate section](./recognizers.md).
 
@@ -551,7 +551,7 @@ some_rule: first second;
 
 For rule `some_rule` action with the name `myaction` will be searched in the
 `<grammar>_actions.py` module, `actions` dict or [built-in
-actions](#built-in-actions) provided by the `parglare.actions` module. This is
+actions](./actions.md/#built-in-actions) provided by the `parglare.actions` module. This is
 helpful if you have some common action that can be used for multiple rules in
 your grammar. Also this can be used to specify built-in action to be used for a
 rule directly in the grammar.

--- a/docs/grammar_modularization.md
+++ b/docs/grammar_modularization.md
@@ -165,7 +165,7 @@ all actions decorated by it and that dictionary will be provided as
 
 By default, a name of a decorated function will serve as a grammar symbol name
 or in-grammar defined action name (using `@`, see [syntax for action
-specification](./grammar_language.md#referencing-rule-actions-from-a-grammar))
+specification](./grammar_language.md#referencing-semantic-actions-from-a-grammar))
 this action is defined for. But, you can provide different name using a string
 parameter to `action` decorator:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ A pure Python LR/GLR parser.
     recognizers](./recognizers.md) for your input stream. The built-in
     recognizers are string and regex recognizers for parsing textual inputs. See
     `recognizers` parameter to grammar construction in the [test_recognizers.py
-    test](https://github.com/igordejanovic/parglare/blob/master/tests/func/test_recognizers.py).
+    test](https://github.com/igordejanovic/parglare/blob/master/tests/func/recognizers/test_recognizers.py).
 
 * [**Flexible actions calling strategies**](./actions.md)
 


### PR DESCRIPTION
Several of the links in the documentation were broken or pointed to the
wrong place (mostly due to re-organized files and changed headings).

All links in the docs should be up to date after this PR.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
