### PR TITLE
Store node reference in visitor's cache.

### DIFF
--- a/parglare/trees.py
+++ b/parglare/trees.py
@@ -397,7 +397,9 @@ def visitor(root, iterator, visit, memoize=True, check_cycle=False):
                 visiting.remove(id(node))
             result = visit(node, results, len(stack))
             if memoize:
-                cache[id(node)] = result
+                # Store node to preserve the reference to it.
+                # Otherwise node may be freed by garbage collector.
+                cache[id(node)] = result, node
             if stack:
                 stack[-1][-1].append(result)
             continue
@@ -406,7 +408,7 @@ def visitor(root, iterator, visit, memoize=True, check_cycle=False):
                             'Last elements: {}'.format(next_elem,
                                                        [r[0] for r in stack[-10:]]))
         if memoize and id(next_elem) in cache:
-            results.append(cache[id(next_elem)])
+            results.append(cache[id(next_elem)][0])
         else:
             stack.append((next_elem, iterator(next_elem), []))
             if check_cycle:


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/

Hi, @igordejanovic ,

I've made the fix according to our today's discussion.

It may not be guaranteed that the `node` is always preserved during the whole `visitor` execution (e.g. if the `node` is not the AST node, but the tuple containing it). This is the rationale for keeping the reference to the `node` object in `cache`.

Best,
Vladimir