### PR TITLE
_pg_extras field stores an arbitrary user-defined object.

### DIFF
--- a/parglare/grammar.py
+++ b/parglare/grammar.py
@@ -1657,13 +1657,15 @@ def _create_prods(context, rhs_prods, name, rule_meta_datas):
                 _pg_children(list): A list of child nodes.
                 _pg_children_names(list): A list of child node names
                     (i.e. LHS of assignments)
+                _pg_extras(object): An arbitrary user-defined object.
 
             """
 
             __slots__ = list(attrs) + ['_pg_start_position',
                                        '_pg_end_position',
                                        '_pg_children',
-                                       '_pg_children_names']
+                                       '_pg_children_names',
+                                       '_pg_extras']
 
             _pg_attrs = attrs
 


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/

Hi, @igordejanovic ,

As we discussed, I have introduced a slot (`_pg_extras`) for storing an arbitrary user-defined object.

Kind regards,
Vladimir
