### PR TITLE
Wider version range for click

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 [options]
 packages = parglare, parglare.tables
 zip_safe = False
-install_requires = click >=7.0, <8.0
+install_requires = click >=7.0, <9.0
 include_package_data = True
 package_dir =
     parglare = parglare


### PR DESCRIPTION
This MR simply extends the `click` dependency range, to include the 8.x series. 
Click 8.x dropped support for Python 2 and 3.5, which are not supported by parglare. 

There does not seem to be other breaking changes in click that impact the `pglr` command.

This is needed as more and more packages require click 8.x, and will provide a workaround for #26.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Commit messages are meaningful (see [this][commit messages] for details)
- [X] Tests have been included and/or updated
- [X] Docstrings have been included and/or updated, as appropriate
- [X] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
